### PR TITLE
Fix master

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -317,7 +317,7 @@ module.exports = grammar({
     import: $ => choice(
       $._variable,
       $._qualified_constructor,
-      seq(
+      prec.dynamic(1, seq(
         $._qualified_type_constructor_identifier,
         optional(choice(
           $.all_constructors,
@@ -327,7 +327,7 @@ module.exports = grammar({
             ')'
           )
         ))
-      ),
+      )),
       seq(
         alias($._constructor_identifier, $.type_class_identifier),
         optional(choice(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -871,94 +871,98 @@
           "name": "_qualified_constructor"
         },
         {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_qualified_type_constructor_identifier"
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "all_constructors"
-                    },
-                    {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "("
-                        },
-                        {
-                          "type": "CHOICE",
-                          "members": [
-                            {
-                              "type": "SEQ",
-                              "members": [
-                                {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SYMBOL",
-                                      "name": "_variable"
-                                    },
-                                    {
-                                      "type": "SYMBOL",
-                                      "name": "_qualified_constructor"
-                                    }
-                                  ]
-                                },
-                                {
-                                  "type": "REPEAT",
-                                  "content": {
-                                    "type": "SEQ",
+          "type": "PREC_DYNAMIC",
+          "value": 1,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_qualified_type_constructor_identifier"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "all_constructors"
+                      },
+                      {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": "("
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SEQ",
+                                "members": [
+                                  {
+                                    "type": "CHOICE",
                                     "members": [
                                       {
-                                        "type": "STRING",
-                                        "value": ","
+                                        "type": "SYMBOL",
+                                        "name": "_variable"
                                       },
                                       {
-                                        "type": "CHOICE",
-                                        "members": [
-                                          {
-                                            "type": "SYMBOL",
-                                            "name": "_variable"
-                                          },
-                                          {
-                                            "type": "SYMBOL",
-                                            "name": "_qualified_constructor"
-                                          }
-                                        ]
+                                        "type": "SYMBOL",
+                                        "name": "_qualified_constructor"
                                       }
                                     ]
+                                  },
+                                  {
+                                    "type": "REPEAT",
+                                    "content": {
+                                      "type": "SEQ",
+                                      "members": [
+                                        {
+                                          "type": "STRING",
+                                          "value": ","
+                                        },
+                                        {
+                                          "type": "CHOICE",
+                                          "members": [
+                                            {
+                                              "type": "SYMBOL",
+                                              "name": "_variable"
+                                            },
+                                            {
+                                              "type": "SYMBOL",
+                                              "name": "_qualified_constructor"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
                                   }
-                                }
-                              ]
-                            },
-                            {
-                              "type": "BLANK"
-                            }
-                          ]
-                        },
-                        {
-                          "type": "STRING",
-                          "value": ")"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            }
-          ]
+                                ]
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          },
+                          {
+                            "type": "STRING",
+                            "value": ")"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
+          }
         },
         {
           "type": "SEQ",


### PR DESCRIPTION
This patch is to correct errors in CI after merging https://github.com/tree-sitter/tree-sitter-haskell/pull/20. The change in that patch isn't related to the errors in CI. This is in part evidenced by trying to revert #20 via #23 but the errors in CI remain. Local testing also confirms that reverting the external scanner change does not make the tests pass.

@maxbrunsfeld's [comment](https://github.com/tree-sitter/tree-sitter-haskell/pull/23#issuecomment-435637634) indicates a possible tree-sitter runtime change affecting the way ambiguities are resolved. This sounds like a strong possibility in the remaining error related to `function_application` and `constructor_pattern`. Although there is not a direct dynamic precedence relationship between them, the productions using `function_application` and the `constructor_pattern` productions involve a complex conflict and precedence relationship that is not easy to untangle.

- [x] Fix `type_class_identifier` vs `type_constructor_identifier` failures
- [ ]  Fix `function_application` failure

Some initial poking at the `function_application` failure didn't produce a positive outcome. I'll continue to poke at this to get master back to green.