### PR TITLE
add includes for MSVC

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -4,6 +4,8 @@
 #include <iostream>
 #include <functional>
 #include <algorithm>
+#include <string>
+#include <iterator>
 
 using namespace std;
 


### PR DESCRIPTION
`#include <string>` is needed for `std::to_string()` on MSVC.
`#include <iterator>` is needed for `back_inserter()` on MSVC.