### PR TITLE
Improve Haskell highlight queries

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,43 +1,125 @@
-(variable) @variable
-(operator) @operator
-(exp_name (constructor) @constructor)
-(constructor_operator) @operator
-(module) @module_name
-(type) @type
-(type) @class
-(constructor) @constructor
-(pragma) @pragma
+;; ----------------------------------------------------------------------------
+;; Literals and comments
+
+(integer) @number
+(exp_negation) @number
+(exp_literal (float)) @float
+(char) @character
+(string) @string
+
+(con_unit) @symbol  ; unit, as in ()
+
 (comment) @comment
-(signature name: (variable) @fun_type_name)
-(function name: (variable) @fun_name)
-(constraint class: (class_name (type)) @class)
-(class (class_head class: (class_name (type)) @class))
-(instance (instance_head class: (class_name (type)) @class))
-(integer) @literal
-(exp_literal (float)) @literal
-(char) @literal
-(con_unit) @literal
-(con_list) @literal
-(tycon_arrow) @operator
-(where) @keyword
-"module" @keyword
-"let" @keyword
-"in" @keyword
-"class" @keyword
-"instance" @keyword
-"data" @keyword
-"newtype" @keyword
-"family" @keyword
-"type" @keyword
-"import" @keyword
-"qualified" @keyword
-"as" @keyword
-"deriving" @keyword
-"via" @keyword
-"stock" @keyword
-"anyclass" @keyword
-"do" @keyword
-"mdo" @keyword
-"rec" @keyword
-"(" @paren
-")" @paren
+
+
+;; ----------------------------------------------------------------------------
+;; Punctuation
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
+] @punctuation.bracket
+
+[
+  (comma)
+  ";"
+] @punctuation.delimiter
+
+
+;; ----------------------------------------------------------------------------
+;; Keywords, operators, includes
+
+[
+  "forall"
+  "∀"
+] @repeat
+
+(pragma) @constant.macro
+
+[
+  "if"
+  "then"
+  "else"
+  "case"
+  "of"
+] @conditional
+
+[
+  "import"
+  "qualified"
+  "module"
+] @include
+
+[
+  (operator)
+  (constructor_operator)
+  (type_operator)
+  (tycon_arrow)
+  (qualified_module)  ; grabs the `.` (dot), ex: import System.IO
+  (all_names)
+  (wildcard)
+  "="
+  "|"
+  "::"
+  "=>"
+  "->"
+  "<-"
+  "\\"
+  "`"
+  "@"
+] @operator
+
+(qualified_module (module) @constructor)
+(qualified_type (module) @namespace)
+(qualified_variable (module) @namespace)
+(import (module) @namespace)
+
+[
+  (where)
+  "let"
+  "in"
+  "class"
+  "instance"
+  "data"
+  "newtype"
+  "family"
+  "type"
+  "as"
+  "hiding"
+  "deriving"
+  "via"
+  "stock"
+  "anyclass"
+  "do"
+  "mdo"
+  "rec"
+] @keyword
+
+
+;; ----------------------------------------------------------------------------
+;; Functions and variables
+
+(signature name: (variable) @type)
+(function name: (variable) @function)
+
+(variable) @variable
+"_" @variable.special
+
+(exp_infix (variable) @operator)  ; consider infix functions as operators
+
+("@" @namespace)  ; "as" pattern operator, e.g. x@Constructor
+
+
+;; ----------------------------------------------------------------------------
+;; Types
+
+(type) @type
+
+(constructor) @constructor
+
+; True or False
+((constructor) @_bool (#match? @_bool "(True|False)")) @boolean


### PR DESCRIPTION
This PR makes improvements to the `highlights.scm` file in 
`tree-sitter-haskell`.

It's partly based off the one by @elianiva from https://github.com/nvim-treesitter/nvim-treesitter/pull/1210.
(I'm aware that PR is still in the works, so wasn't sure whether to open the PR 
here or on the `nvim-treesitter` repo).

Here are the changes I've made compared to the one from the `nvim-treesitter` 
PR:

* Highlight minus sign in negated numbers, e.g. (-10)
* Resolve error when comma captured as punctuation delimiter (previously
  commented out)
* Add semicolon as punctuation delimiter
* Add `case` and `of` to `@conditional` capture group
* Move `qualified` out of `@keyword` and into `@include` capture group
* Add missing operators:
  * `type_operator`
  * Dots from export and record wildcards, i.e. `Record{..}`, `exp (..)`
  * Equals and pipe `=` and `|`
  * Function arrows `=>` and `->`
  * Bind arrow `<-`
  * Lambda operator `\`
  * Treat infix functions as operators (and also highlight the backtick)
  * `@` symbol (except for in the as-pattern, where it is highlighted as
    `@namespace`)
* Highlight namespaces with `@namespace` instead of `@constructor`, e.g.
  in `T.Text`
* Simplify queries for types

There's also a comparison of each of the aforementioned highlights, so you can see the results visually.

_Example 1_

| `tree-sitter-haskell` | `nvim-treesitter` PR | This PR |
| -- | -- | -- |
| ![screenshot_20210618_213617](https://user-images.githubusercontent.com/12140044/122615742-f7664c80-d080-11eb-9079-031279fe45c7.png) | ![screenshot_20210618_214054](https://user-images.githubusercontent.com/12140044/122615937-5330d580-d081-11eb-8e7a-92c7523951e4.png) | ![screenshot_20210618_215022](https://user-images.githubusercontent.com/12140044/122615836-28df1800-d081-11eb-8f22-459da2904d03.png) |

_Example 2_

| `tree-sitter-haskell` | `nvim-treesitter` PR | This PR |
| -- | -- | -- |
| ![screenshot_20210618_213740](https://user-images.githubusercontent.com/12140044/122616011-765b8500-d081-11eb-9a39-7e5bba93e111.png) | ![screenshot_20210618_214235](https://user-images.githubusercontent.com/12140044/122616026-807d8380-d081-11eb-96ff-032f4e72460a.png) | ![screenshot_20210618_215113](https://user-images.githubusercontent.com/12140044/122616031-85dace00-d081-11eb-885d-9397008abf63.png) |

