### PR TITLE
[wip] Faster scanner

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -765,6 +765,7 @@ namespace parser {
  * The main function shape for all parser combinators.
  */
 typedef function<Result(State&)> Parser;
+typedef Result (*NewParser)(State&);
 
 /**
  * Parsers that depend on the next character.
@@ -1543,7 +1544,10 @@ Parser main =
 /**
  * The entry point to the parser.
  */
-Parser all = init + main;
+Result all(State &state) {
+  auto res = init(state);
+  return res.finished ? res : main(state);
+}
 
 }
 
@@ -1583,7 +1587,7 @@ void debug_lookahead(State & state) {
   *
   * If the `debug_next_token` flag is set, the next token will be printed.
   */
-bool eval(logic::Parser chk, State & state) {
+bool eval(parser::NewParser chk, State & state) {
   auto result = chk(state);
   if (debug_next_token) debug_lookahead(state);
   if (result.finished && result.sym != Sym::fail) {

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -1410,7 +1410,22 @@ Parser brace = seq("{-")(peeks(not_(cond::eq('#')))(multiline_comment(1))) + fai
 /**
  * Parse either inline or block comments.
  */
-Parser comment = peek('-')(minus + fail) + peek('{')(brace);
+Result comment(State &state) {
+  switch (state::next_char(state)) {
+    case '-': {
+      Result res = minus(state);
+      SHORT_SCANNER;
+      return result::fail;
+    }
+    case '{': {
+      Result res = brace(state);
+      SHORT_SCANNER;
+      return result::fail;
+    }
+  }
+  return result::cont;
+}
+// Parser minus = seq("--")(consume_while(cond::eq('-')) + peeks(cond::symbolic)(fail) + inline_comment);
 
 /**
  * `case` can open a layout in a list:


### PR DESCRIPTION
The least invasive way to make this scanner performant seems to be to:

* remove uses of `std::function`
* lower and inline combinator logic
* remove currying (c++ closures = a bad time)

For background, see https://github.com/tree-sitter/tree-sitter-haskell/issues/41

These are mostly mechanical changes, so they should be easy enough to review.  
If you see a better way to lower something into fast, first-order logic, let me know :)

As our benchmark, this is on my laptop on `master`:

```
$ ./script/parse-example effects
Successfully parsed 100.00% of 'effects' in 1.06s (38 of 38 files)
```

And this is on the current branch:

```
$ ./script/parse-example effects
Successfully parsed 100.00% of 'effects' in 0.59s (38 of 38 files)
```

I'll post timings after I push commits.

---

### Risk assessment:

As the changes are mostly mechanical, we shouldn't risk breaking anything too badly.  
It's also trivial to mix the old `Parser` type and straight up c++ functions, so it's easy to change a small function, get it compiling, and run `tree-sitter test`.

It is technically possible to merge this branch as is, with the only partially-converted scanner.  
@tek it's up to you how you want to proceed here. I'm happy to split this up into small PRs, or just keep adding to this branch.

---

### This code looks worse

I actually don't think it's that bad.  
There's something nice about having simple first-order functions.  
I think it's equivalently bad to having `"pure"` parsers with side-effects ;)  
It will also be pretty easy to convert this to pure `C` when we're finished (which I would be in favor of)