### PR TITLE
Convert scanner to C for great good (~˘▾˘)~

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,5 +22,18 @@ node_modules/web-tree-sitter:
 
 # build web version of tree-sitter-haskell
 # NOTE: requires patched version of web-tree-sitter
-tree-sitter-haskell.wasm: src/parser.c src/scanner.cc
+tree-sitter-haskell.wasm: src/parser.c src/scanner.c
 	npx tree-sitter build-wasm
+
+CC := cc
+OURCFLAGS := -shared -fPIC -g -O0 -I src
+
+clean:
+	rm -f debug *.o *.a
+
+debug.so: src/parser.c src/scanner.c
+	$(CC) $(CFLAGS) -o parser.o  $(OURCFLAGS) src/parser.c
+	$(CC) $(CFLAGS) -o scanner.o $(OURCFLAGS) src/scanner.c
+	$(CC) $(CFLAGS) -o debug.so $(OURCFLAGS) $(PWD)/scanner.o $(PWD)/parser.o
+	rm -f $(HOME)/.cache/tree-sitter/lib/haskell.so
+	cp $(PWD)/debug.so $(HOME)/.cache/tree-sitter/lib/haskell.so


### PR DESCRIPTION
This should solve all past and future portability issues, because the C runtime is pretty ubiquitous.

The only generics we were using was in `vector`s, which I've preserved, with some macros.

C has no u32string, so I've used the vector macros to solve that too.

We lose namespaces ¯\\_(ツ)_/¯.

The code is structurally the exact same.

We seem to have gained a bit of speed, compared to the C++ version (probably not statistically significant):

| project | % parsed | time |
| --- | --- | --- |
| effects | 100.00% | 0.0322s |
| postgrest | 100.00% | 0.0769s |
| ivory | 100.00% | 0.2119s |
| polysemy | 98.75% | 0.0807s |
| semantic | 97.60% | 1.0335s |
| haskell-language-server | 99.79% | 0.4648s |


@wenkokke does this remove the need to patch `tree-sitter` for your wasm builds?  
After this change, `stdio.h` is only required for `-DDEBUG` builds.