### PR TITLE
Add skipping back to C scanner

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -21,7 +21,10 @@
 // short circuit
 #define SHORT_SCANNER if (res.finished) return res;
 #define PEEK state->lexer->lookahead
+// Move the parser position one character to the right.
 #define S_ADVANCE state->lexer->advance(state->lexer, false)
+// Move the parser position one character to the right, treating the consumed character as whitespace.
+#define S_SKIP state->lexer->advance(state->lexer, true)
 #define SYM(s) (state->symbols[s])
 
 #ifdef DEBUG
@@ -249,11 +252,6 @@ static bool is_eof(State *state) { return state->lexer->eof(state->lexer); }
 static uint32_t column(State *state) {
   return is_eof(state) ? 0 : state->lexer->get_column(state->lexer);
 }
-
-/**
- * Move the parser position one character to the right, treating the consumed character as whitespace.
- */
-static void skip(State *state) { state->lexer->advance(state->lexer, true); }
 
 /**
  * Instruct the lexer that the current position is the end of the potentially detected symbol, causing the next run to
@@ -680,7 +678,7 @@ static void skipspace(State *state) {
     switch (PEEK) {
       case ' ':
       case '\t':
-        S_ADVANCE;
+        S_SKIP;
         break;
       default:
         return;
@@ -728,15 +726,15 @@ static uint32_t count_indent(State *state) {
   for (;;) {
     switch (PEEK) {
       NEWLINE_CASES:
-        S_ADVANCE;
+        S_SKIP;
         indent = 0;
         break;
       case ' ':
-        S_ADVANCE;
+        S_SKIP;
         indent++;
         break;
       case '\t':
-        S_ADVANCE;
+        S_SKIP;
         indent += 8;
         break;
       default:
@@ -1480,7 +1478,7 @@ static Result scan_main(State *state) {
   SHORT_SCANNER;
   MARK("main", false, state);
   if (is_newline(PEEK)) {
-    S_ADVANCE;
+    S_SKIP;
     uint32_t indent = count_indent(state);
     return newline(indent, state);
   }


### PR DESCRIPTION
I noticed that I'd accidentally changed a side-effect produced by the scanner.  
I'm not entirely sure what this does, it certainly doesn't change any test results.

@tek ready to merge