### PR TITLE
Add fixity keywords to highlights query

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -97,6 +97,9 @@
   "do"
   "mdo"
   "rec"
+  "infix"
+  "infixl"
+  "infixr"
 ] @keyword
 
 


### PR DESCRIPTION
A small change to add fixity declaration keywords (`infix`, `infixl`, `infixr`) to highlights query.

| Before                                                                                                         | After                                                                                                          |
| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
| ![image](https://user-images.githubusercontent.com/4299733/148446863-f10555ee-04b1-40a1-82a1-02f2ba79241c.png) | ![image](https://user-images.githubusercontent.com/4299733/148447013-da735b65-63c3-4e4c-a34b-17aa5e9a5136.png) |
