### PR TITLE
Improve highlights query for functions

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -106,13 +106,17 @@
 ;; ----------------------------------------------------------------------------
 ;; Functions and variables
 
-(signature name: (variable) @type)
-(function name: (variable) @function)
-
 (variable) @variable
 "_" @variable.special
 
+(signature name: (variable) @type)
+(function
+  name: (variable) @function
+  patterns: (patterns))
+
 (exp_infix (variable) @operator)  ; consider infix functions as operators
+
+(exp_apply . (exp_name (variable) @function))
 
 ("@" @namespace)  ; "as" pattern operator, e.g. x@Constructor
 


### PR DESCRIPTION
I moved the queries for function declaration and type signature after the query for variable.
I don't know why it didn't work before.

| Before                                                                                                         | After                                                                                                          |
| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
| ![image](https://user-images.githubusercontent.com/4299733/148473391-9c75d9c9-9746-4f4b-9f03-16dc2f1f4981.png) | ![image](https://user-images.githubusercontent.com/4299733/148473186-b77f0f6a-cf0a-4f61-a47a-6d7b9d0a56d4.png) |
