### PR TITLE
Unicode identifiers

### DIFF
--- a/grammar/id.js
+++ b/grammar/id.js
@@ -5,8 +5,13 @@ module.exports = {
   // var
   // ------------------------------------------------------------------------
 
-  _varid: _ => /[_a-z](\w|')*#?/,
-  label: _ => /#[_a-z](\w|')*/,
+  // https://www.haskell.org/onlinereport/lexemes.html
+  //
+  // varid: "small { small | large | digit | ' }" per the report,
+  // where small: ascSmall | uniSmall | _ (and uniSmall is a superset of ascSmall)
+  // Then, uniSmall is implemented as the unicode class "Ll": letter lowercase
+  _varid: _ => /[_\p{Ll}](\w|')*#?/u,
+  label: _ => /#[_\p{Ll}](\w|')*/u,
   variable: $ => $._varid,
   qualified_variable: $ => qualified($, $.variable),
   _qvarid: $ => choice($.qualified_variable, $.variable),
@@ -25,13 +30,17 @@ module.exports = {
   _qvarop: $ => choice($._qvarsym, ticked($._qvarid)),
   _qvarop_nominus: $ => choice($._qvarsym_nominus, ticked($._qvarid)),
 
-  implicit_parid: _ => /\?[_a-z](\w|')*/,
+  implicit_parid: _ => /\?[_\p{Ll}](\w|')*/u,
 
   // ------------------------------------------------------------------------
   // con
   // ------------------------------------------------------------------------
 
-  _conid: _ => /[A-Z](\w|')*#?/,
+  // per the report,
+  //   conid: "large { small | large | digit | ' }"
+  // large (via uniLarge) is "any uppercase or titlecase unicode character"
+  // which are the unicode categories "Lu": letter uppercase, "Lt": letter titlecase
+  _conid: _ => /[\p{Lu}\p{Lt}](\w|')*#?/u,
   constructor: $ => $._conid,
   qualified_constructor: $ => qualified($, $.constructor),
   _qconid: $ => choice($.qualified_constructor, $.constructor),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -624,11 +624,11 @@
     },
     "_varid": {
       "type": "PATTERN",
-      "value": "[_a-z](\\w|')*#?"
+      "value": "[_\\p{Ll}](\\w|')*#?"
     },
     "label": {
       "type": "PATTERN",
-      "value": "#[_a-z](\\w|')*"
+      "value": "#[_\\p{Ll}](\\w|')*"
     },
     "variable": {
       "type": "SYMBOL",
@@ -857,11 +857,11 @@
     },
     "implicit_parid": {
       "type": "PATTERN",
-      "value": "\\?[_a-z](\\w|')*"
+      "value": "\\?[_\\p{Ll}](\\w|')*"
     },
     "_conid": {
       "type": "PATTERN",
-      "value": "[A-Z](\\w|')*#?"
+      "value": "[\\p{Lu}\\p{Lt}](\\w|')*#?"
     },
     "constructor": {
       "type": "SYMBOL",

--- a/test/corpus/id.txt
+++ b/test/corpus/id.txt
@@ -50,7 +50,23 @@ id: unicode
 ================================================================================
 
 accenté = ()
+data T =
+  Œufs
+  | Étonnement
+  | ǋtitlecasetest
 
 ---
 
-()
+(haskell
+  (function (variable)
+    (patterns (pat_name (variable)))
+    (exp_literal (con_unit)))
+  (adt
+    (type)
+    (constructors
+      (data_constructor
+        (constructor))
+      (data_constructor
+        (constructor))
+      (data_constructor
+        (constructor)))))

--- a/test/corpus/id.txt
+++ b/test/corpus/id.txt
@@ -44,3 +44,13 @@ data B = A
    (data_constructor (constructor))
    (data_constructor (constructor))
    (data_constructor (constructor)))))
+
+================================================================================
+id: unicode
+================================================================================
+
+accenté = ()
+
+---
+
+()


### PR DESCRIPTION
This is part of the bugfixing I am doing after running tree-sitter-haskell against the Mercury codebase.

The original bad parse was that there were some French names that were spelled with accents, which were previously rejected by the parser.