### PR TITLE
fix: free indents on destroy

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1649,4 +1649,5 @@ void tree_sitter_haskell_external_scanner_deserialize(void *indents_v, char *buf
 void tree_sitter_haskell_external_scanner_destroy(void *indents_v) {
   indent_vec *indents = (indent_vec*) indents_v;
   VEC_FREE(indents);
+  free(indents);
 }


### PR DESCRIPTION
Detected this via fuzzing w/ libfuzzer