### PR TITLE
Correctly parse `\cases` expressions

### DIFF
--- a/grammar/exp.js
+++ b/grammar/exp.js
@@ -180,7 +180,7 @@ module.exports = {
   ),
 
   alt: $ => seq($._pat, $._alt_variants, optional(seq($.where, optional($.decls)))),
-  nalt: $ => seq(repeat1($._pat), $._alt_variants, optional(seq($.where, optional($.decls)))),
+  nalt: $ => seq(repeat1($._apat), $._alt_variants, optional(seq($.where, optional($.decls)))),
 
   alts: $ => layouted($, $.alt),
   nalts: $ => layouted($, $.nalt),

--- a/grammar/exp.js
+++ b/grammar/exp.js
@@ -199,11 +199,11 @@ module.exports = {
   /**
    * alts are NOT optional in a \cases expression
    */
-	exp_lambda_cases: $ => seq(
+  exp_lambda_cases: $ => seq(
     '\\',
     'cases',
     $.nalts,
-	),
+  ),
 
   rec: $ => seq(
     'rec',

--- a/grammar/exp.js
+++ b/grammar/exp.js
@@ -180,8 +180,10 @@ module.exports = {
   ),
 
   alt: $ => seq($._pat, $._alt_variants, optional(seq($.where, optional($.decls)))),
+  nalt: $ => seq(repeat1($._pat), $._alt_variants, optional(seq($.where, optional($.decls)))),
 
   alts: $ => layouted($, $.alt),
+  nalts: $ => layouted($, $.nalt),
 
   exp_case: $ => seq('case', $._exp, 'of', optional($.alts)),
 
@@ -193,6 +195,15 @@ module.exports = {
     'case',
     optional($.alts),
   ),
+
+  /**
+   * alts are NOT optional in a \cases expression
+   */
+	exp_lambda_cases: $ => seq(
+    '\\',
+    'cases',
+    $.nalts,
+	),
 
   rec: $ => seq(
     'rec',
@@ -293,6 +304,7 @@ module.exports = {
     $._aexp_projection,
     $.exp_type_application,
     $.exp_lambda_case,
+    $.exp_lambda_cases,
     $.exp_do,
     $.exp_projection,
   ),

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -62,6 +62,8 @@
   "of"
 ] @conditional
 
+(exp_lambda_cases "\\" ("cases" @conditional))
+
 [
   "import"
   "qualified"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4324,7 +4324,7 @@
           "type": "REPEAT1",
           "content": {
             "type": "SYMBOL",
-            "name": "_pat"
+            "name": "_apat"
           }
         },
         {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4317,6 +4317,51 @@
         }
       ]
     },
+    "nalt": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_pat"
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_alt_variants"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "where"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "decls"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
+    },
     "alts": {
       "type": "CHOICE",
       "members": [
@@ -4480,6 +4525,169 @@
         }
       ]
     },
+    "nalts": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "{"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ";"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "nalt"
+                    },
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "REPEAT1",
+                            "content": {
+                              "type": "STRING",
+                              "value": ";"
+                            }
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "nalt"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": ";"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": "}"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_layout_start"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "nalt"
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "PREC_DYNAMIC",
+                                "value": 1,
+                                "content": {
+                                  "type": "CHOICE",
+                                  "members": [
+                                    {
+                                      "type": "STRING",
+                                      "value": ";"
+                                    },
+                                    {
+                                      "type": "SYMBOL",
+                                      "name": "_layout_semicolon"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "nalt"
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": ";"
+                            },
+                            {
+                              "type": "SYMBOL",
+                              "name": "_layout_semicolon"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_layout_end"
+            }
+          ]
+        }
+      ]
+    },
     "exp_case": {
       "type": "SEQ",
       "members": [
@@ -4531,6 +4739,23 @@
               "type": "BLANK"
             }
           ]
+        }
+      ]
+    },
+    "exp_lambda_cases": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "\\"
+        },
+        {
+          "type": "STRING",
+          "value": "cases"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "nalts"
         }
       ]
     },
@@ -5178,6 +5403,10 @@
         {
           "type": "SYMBOL",
           "name": "exp_lambda_case"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "exp_lambda_cases"
         },
         {
           "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -9853,15 +9853,7 @@
           "named": true
         },
         {
-          "type": "pat_apply",
-          "named": true
-        },
-        {
           "type": "pat_as",
-          "named": true
-        },
-        {
-          "type": "pat_infix",
           "named": true
         },
         {
@@ -9878,10 +9870,6 @@
         },
         {
           "type": "pat_name",
-          "named": true
-        },
-        {
-          "type": "pat_negation",
           "named": true
         },
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -267,6 +267,10 @@
           "named": true
         },
         {
+          "type": "exp_lambda_cases",
+          "named": true
+        },
+        {
           "type": "exp_let_in",
           "named": true
         },
@@ -639,6 +643,10 @@
         },
         {
           "type": "exp_lambda_case",
+          "named": true
+        },
+        {
+          "type": "exp_lambda_cases",
           "named": true
         },
         {
@@ -2022,6 +2030,10 @@
             "named": true
           },
           {
+            "type": "exp_lambda_cases",
+            "named": true
+          },
+          {
             "type": "exp_let_in",
             "named": true
           },
@@ -2486,6 +2498,10 @@
           "named": true
         },
         {
+          "type": "exp_lambda_cases",
+          "named": true
+        },
+        {
           "type": "exp_let_in",
           "named": true
         },
@@ -2610,6 +2626,10 @@
           },
           {
             "type": "exp_lambda_case",
+            "named": true
+          },
+          {
+            "type": "exp_lambda_cases",
             "named": true
           },
           {
@@ -2799,6 +2819,10 @@
             "named": true
           },
           {
+            "type": "exp_lambda_cases",
+            "named": true
+          },
+          {
             "type": "exp_let_in",
             "named": true
           },
@@ -2982,6 +3006,10 @@
           },
           {
             "type": "exp_lambda_case",
+            "named": true
+          },
+          {
+            "type": "exp_lambda_cases",
             "named": true
           },
           {
@@ -3332,6 +3360,10 @@
           "named": true
         },
         {
+          "type": "exp_lambda_cases",
+          "named": true
+        },
+        {
           "type": "exp_let_in",
           "named": true
         },
@@ -3460,6 +3492,10 @@
           },
           {
             "type": "exp_lambda_case",
+            "named": true
+          },
+          {
+            "type": "exp_lambda_cases",
             "named": true
           },
           {
@@ -3649,6 +3685,10 @@
             "named": true
           },
           {
+            "type": "exp_lambda_cases",
+            "named": true
+          },
+          {
             "type": "exp_let_in",
             "named": true
           },
@@ -3832,6 +3872,10 @@
           },
           {
             "type": "exp_lambda_case",
+            "named": true
+          },
+          {
+            "type": "exp_lambda_cases",
             "named": true
           },
           {
@@ -4227,6 +4271,10 @@
           "named": true
         },
         {
+          "type": "exp_lambda_cases",
+          "named": true
+        },
+        {
           "type": "exp_let_in",
           "named": true
         },
@@ -4444,6 +4492,10 @@
           "named": true
         },
         {
+          "type": "exp_lambda_cases",
+          "named": true
+        },
+        {
           "type": "exp_let_in",
           "named": true
         },
@@ -4572,6 +4624,10 @@
         },
         {
           "type": "exp_lambda_case",
+          "named": true
+        },
+        {
+          "type": "exp_lambda_cases",
           "named": true
         },
         {
@@ -4797,6 +4853,10 @@
           "named": true
         },
         {
+          "type": "exp_lambda_cases",
+          "named": true
+        },
+        {
           "type": "exp_let_in",
           "named": true
         },
@@ -4937,6 +4997,21 @@
       "types": [
         {
           "type": "alts",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "exp_lambda_cases",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "nalts",
           "named": true
         }
       ]
@@ -5097,6 +5172,10 @@
         },
         {
           "type": "exp_lambda_case",
+          "named": true
+        },
+        {
+          "type": "exp_lambda_cases",
           "named": true
         },
         {
@@ -5302,6 +5381,10 @@
           "named": true
         },
         {
+          "type": "exp_lambda_cases",
+          "named": true
+        },
+        {
           "type": "exp_let_in",
           "named": true
         },
@@ -5495,6 +5578,10 @@
           "named": true
         },
         {
+          "type": "exp_lambda_cases",
+          "named": true
+        },
+        {
           "type": "exp_list",
           "named": true
         },
@@ -5682,6 +5769,10 @@
         },
         {
           "type": "exp_lambda_case",
+          "named": true
+        },
+        {
+          "type": "exp_lambda_cases",
           "named": true
         },
         {
@@ -5898,6 +5989,10 @@
           "named": true
         },
         {
+          "type": "exp_lambda_cases",
+          "named": true
+        },
+        {
           "type": "exp_list",
           "named": true
         },
@@ -6018,6 +6113,10 @@
         },
         {
           "type": "exp_lambda_case",
+          "named": true
+        },
+        {
+          "type": "exp_lambda_cases",
           "named": true
         },
         {
@@ -6173,6 +6272,10 @@
         },
         {
           "type": "exp_lambda_case",
+          "named": true
+        },
+        {
+          "type": "exp_lambda_cases",
           "named": true
         },
         {
@@ -6489,6 +6592,10 @@
           "named": true
         },
         {
+          "type": "exp_lambda_cases",
+          "named": true
+        },
+        {
           "type": "exp_let_in",
           "named": true
         },
@@ -6742,6 +6849,10 @@
           "named": true
         },
         {
+          "type": "exp_lambda_cases",
+          "named": true
+        },
+        {
           "type": "exp_let_in",
           "named": true
         },
@@ -6941,6 +7052,10 @@
         },
         {
           "type": "exp_lambda_case",
+          "named": true
+        },
+        {
+          "type": "exp_lambda_cases",
           "named": true
         },
         {
@@ -7692,6 +7807,10 @@
             "named": true
           },
           {
+            "type": "exp_lambda_cases",
+            "named": true
+          },
+          {
             "type": "exp_let_in",
             "named": true
           },
@@ -8172,6 +8291,10 @@
           "named": true
         },
         {
+          "type": "exp_lambda_cases",
+          "named": true
+        },
+        {
           "type": "exp_let_in",
           "named": true
         },
@@ -8296,6 +8419,10 @@
         },
         {
           "type": "exp_lambda_case",
+          "named": true
+        },
+        {
+          "type": "exp_lambda_cases",
           "named": true
         },
         {
@@ -8502,6 +8629,10 @@
         },
         {
           "type": "exp_lambda_case",
+          "named": true
+        },
+        {
+          "type": "exp_lambda_cases",
           "named": true
         },
         {
@@ -9521,6 +9652,299 @@
     "type": "module",
     "named": true,
     "fields": {}
+  },
+  {
+    "type": "nalt",
+    "named": true,
+    "fields": {
+      "type": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "context",
+            "named": true
+          },
+          {
+            "type": "forall",
+            "named": true
+          },
+          {
+            "type": "fun",
+            "named": true
+          },
+          {
+            "type": "implicit_param",
+            "named": true
+          },
+          {
+            "type": "promoted",
+            "named": true
+          },
+          {
+            "type": "quasiquote",
+            "named": true
+          },
+          {
+            "type": "splice",
+            "named": true
+          },
+          {
+            "type": "type_apply",
+            "named": true
+          },
+          {
+            "type": "type_infix",
+            "named": true
+          },
+          {
+            "type": "type_list",
+            "named": true
+          },
+          {
+            "type": "type_literal",
+            "named": true
+          },
+          {
+            "type": "type_name",
+            "named": true
+          },
+          {
+            "type": "type_parens",
+            "named": true
+          },
+          {
+            "type": "type_star",
+            "named": true
+          },
+          {
+            "type": "type_tuple",
+            "named": true
+          },
+          {
+            "type": "type_unboxed_sum",
+            "named": true
+          },
+          {
+            "type": "type_unboxed_tuple",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "decls",
+          "named": true
+        },
+        {
+          "type": "exp_apply",
+          "named": true
+        },
+        {
+          "type": "exp_arithmetic_sequence",
+          "named": true
+        },
+        {
+          "type": "exp_case",
+          "named": true
+        },
+        {
+          "type": "exp_cond",
+          "named": true
+        },
+        {
+          "type": "exp_do",
+          "named": true
+        },
+        {
+          "type": "exp_if_guard",
+          "named": true
+        },
+        {
+          "type": "exp_infix",
+          "named": true
+        },
+        {
+          "type": "exp_lambda",
+          "named": true
+        },
+        {
+          "type": "exp_lambda_case",
+          "named": true
+        },
+        {
+          "type": "exp_lambda_cases",
+          "named": true
+        },
+        {
+          "type": "exp_let_in",
+          "named": true
+        },
+        {
+          "type": "exp_list",
+          "named": true
+        },
+        {
+          "type": "exp_list_comprehension",
+          "named": true
+        },
+        {
+          "type": "exp_literal",
+          "named": true
+        },
+        {
+          "type": "exp_name",
+          "named": true
+        },
+        {
+          "type": "exp_negation",
+          "named": true
+        },
+        {
+          "type": "exp_parens",
+          "named": true
+        },
+        {
+          "type": "exp_projection",
+          "named": true
+        },
+        {
+          "type": "exp_projection_selector",
+          "named": true
+        },
+        {
+          "type": "exp_record",
+          "named": true
+        },
+        {
+          "type": "exp_section_left",
+          "named": true
+        },
+        {
+          "type": "exp_section_right",
+          "named": true
+        },
+        {
+          "type": "exp_th_quoted_name",
+          "named": true
+        },
+        {
+          "type": "exp_tuple",
+          "named": true
+        },
+        {
+          "type": "exp_type_application",
+          "named": true
+        },
+        {
+          "type": "exp_unboxed_sum",
+          "named": true
+        },
+        {
+          "type": "exp_unboxed_tuple",
+          "named": true
+        },
+        {
+          "type": "gdpat",
+          "named": true
+        },
+        {
+          "type": "pat_apply",
+          "named": true
+        },
+        {
+          "type": "pat_as",
+          "named": true
+        },
+        {
+          "type": "pat_infix",
+          "named": true
+        },
+        {
+          "type": "pat_irrefutable",
+          "named": true
+        },
+        {
+          "type": "pat_list",
+          "named": true
+        },
+        {
+          "type": "pat_literal",
+          "named": true
+        },
+        {
+          "type": "pat_name",
+          "named": true
+        },
+        {
+          "type": "pat_negation",
+          "named": true
+        },
+        {
+          "type": "pat_parens",
+          "named": true
+        },
+        {
+          "type": "pat_record",
+          "named": true
+        },
+        {
+          "type": "pat_strict",
+          "named": true
+        },
+        {
+          "type": "pat_tuple",
+          "named": true
+        },
+        {
+          "type": "pat_type_binder",
+          "named": true
+        },
+        {
+          "type": "pat_unboxed_sum",
+          "named": true
+        },
+        {
+          "type": "pat_unboxed_tuple",
+          "named": true
+        },
+        {
+          "type": "pat_wildcard",
+          "named": true
+        },
+        {
+          "type": "quasiquote",
+          "named": true
+        },
+        {
+          "type": "splice",
+          "named": true
+        },
+        {
+          "type": "where",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "nalts",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "nalt",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "namespace",
@@ -11234,6 +11658,10 @@
           "named": true
         },
         {
+          "type": "exp_lambda_cases",
+          "named": true
+        },
+        {
           "type": "exp_let_in",
           "named": true
         },
@@ -11563,6 +11991,10 @@
         },
         {
           "type": "exp_lambda_case",
+          "named": true
+        },
+        {
+          "type": "exp_lambda_cases",
           "named": true
         },
         {
@@ -11970,6 +12402,10 @@
         },
         {
           "type": "exp_lambda_case",
+          "named": true
+        },
+        {
+          "type": "exp_lambda_cases",
           "named": true
         },
         {
@@ -12609,6 +13045,10 @@
           "named": true
         },
         {
+          "type": "exp_lambda_cases",
+          "named": true
+        },
+        {
           "type": "exp_let_in",
           "named": true
         },
@@ -12814,6 +13254,10 @@
           "named": true
         },
         {
+          "type": "exp_lambda_cases",
+          "named": true
+        },
+        {
           "type": "exp_let_in",
           "named": true
         },
@@ -13009,6 +13453,10 @@
         },
         {
           "type": "exp_lambda_case",
+          "named": true
+        },
+        {
+          "type": "exp_lambda_cases",
           "named": true
         },
         {
@@ -14546,6 +14994,10 @@
   },
   {
     "type": "case",
+    "named": false
+  },
+  {
+    "type": "cases",
     "named": false
   },
   {


### PR DESCRIPTION
Added support in the grammar for LambdaCase expressions with multiple scrutinees, as described [here](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0302-cases.rst#bnf-changes).

This addition is incomplete, as the `cases` keyword is not correctly highlighted. I was hoping to get assistance with this part; neither of the following changes to queries/highlights.scm seemed to have any effect:
```diff
 [
   "if"
   "then"
   "else"
; unconditionally treat `cases` as a keyword
+  "cases"
   "case"
   "of"
 ] @conditional
 ```
 ```diff
; only treat `cases` as a keyword in a cases lambda (`cases` is a valid id)
 + (exp_lambda_cases "\\" ("cases" @conditional))
```
