### PR TITLE
Add `license` field to `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ keywords = ["incremental", "parsing", "haskell"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/tree-sitter/tree-sitter-haskell"
 edition = "2018"
+license = "MIT"
 
 build = "bindings/rust/build.rs"
 include = [


### PR DESCRIPTION
This PR adds the `license` field to `Cargo.toml`.

This field is required if this package were to be published on crates.io.

More immediately, projects that depend on this crate via Git dependencies (like [Zed](https://github.com/zed-industries/zed)) need this field to be present for [`cargo about`](https://github.com/EmbarkStudios/cargo-about) to correctly identify the license.