### PR TITLE
Enable build by msvc

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -14,7 +14,14 @@
       ],
       "cflags_c": [
         "-std=c99",
-      ]
+      ],
+      "msvs_settings": {
+        "VCCLCompilerTool": {
+          "AdditionalOptions": [
+            '-utf-8'
+          ],
+        },
+      },
     }
   ]
 }

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -6,7 +6,8 @@ fn main() {
     c_config
         .flag_if_supported("-Wno-unused-parameter")
         .flag_if_supported("-Wno-unused-but-set-variable")
-        .flag_if_supported("-Wno-trigraphs");
+        .flag_if_supported("-Wno-trigraphs")
+        .flag_if_supported("-utf-8");
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
 


### PR DESCRIPTION
[`-utf-8`](https://learn.microsoft.com/en-us/cpp/build/reference/utf-8-set-source-and-executable-character-sets-to-utf-8?view=msvc-170) option is needed when compile non-ascii unicode source with MSVC.