### PR TITLE
Regenerate and remove utf-8 chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # tree-sitter-haskell
 
-[![CI](https://github.com/tree-sitter/tree-sitter-haskell/actions/workflows/ci.yml/badge.svg)](https://github.com/tree-sitter/tree-sitter-haskell/actions/workflows/ci.yml)
+[![CI][ci]](https://github.com/tree-sitter/tree-sitter-cpp/actions/workflows/ci.yml)
+[![discord][discord]](https://discord.gg/w7nTvsVJhm)
+[![matrix][matrix]](https://matrix.to/#/#tree-sitter-chat:matrix.org)
+[![crates][crates]](https://crates.io/crates/tree-sitter-cpp)
+[![npm][npm]](https://www.npmjs.com/package/tree-sitter-cpp)
 
 Haskell grammar for [tree-sitter].
 
@@ -231,3 +235,9 @@ If you want to debug the scanner with `gdb`, you can
 ```
 $ tree-sitter parse -D test/Basic.hs    # Produces log.html
 ```
+
+[ci]: https://img.shields.io/github/actions/workflow/status/tree-sitter/tree-sitter-cpp/ci.yml?logo=github&label=CI
+[discord]: https://img.shields.io/discord/1063097320771698699?logo=discord&label=discord
+[matrix]: https://img.shields.io/matrix/tree-sitter-chat%3Amatrix.org?logo=matrix&label=matrix
+[npm]: https://img.shields.io/npm/v/tree-sitter-cpp?logo=npm
+[crates]: https://img.shields.io/crates/v/tree-sitter-cpp?logo=rust

--- a/binding.gyp
+++ b/binding.gyp
@@ -14,14 +14,7 @@
       ],
       "cflags_c": [
         "-std=c99",
-      ],
-      "msvs_settings": {
-        "VCCLCompilerTool": {
-          "AdditionalOptions": [
-            '-utf-8'
-          ],
-        },
-      },
+      ]
     }
   ]
 }

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -6,8 +6,7 @@ fn main() {
     c_config
         .flag_if_supported("-Wno-unused-parameter")
         .flag_if_supported("-Wno-unused-but-set-variable")
-        .flag_if_supported("-Wno-trigraphs")
-        .flag_if_supported("-utf-8");
+        .flag_if_supported("-Wno-trigraphs");
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -687,18 +687,21 @@
     },
     "_varid": {
       "type": "PATTERN",
-      "value": "[_\\p{Ll}](\\w|')*#?"
+      "value": "[_\\p{Ll}](\\w|')*#?",
+      "flags": "u"
     },
     "_immediate_varid": {
       "type": "IMMEDIATE_TOKEN",
       "content": {
         "type": "PATTERN",
-        "value": "[_\\p{Ll}](\\w|')*#?"
+        "value": "[_\\p{Ll}](\\w|')*#?",
+        "flags": "u"
       }
     },
     "label": {
       "type": "PATTERN",
-      "value": "#[_\\p{Ll}](\\w|')*"
+      "value": "#[_\\p{Ll}](\\w|')*",
+      "flags": "u"
     },
     "variable": {
       "type": "SYMBOL",
@@ -936,11 +939,13 @@
     },
     "implicit_parid": {
       "type": "PATTERN",
-      "value": "\\?[_\\p{Ll}](\\w|')*"
+      "value": "\\?[_\\p{Ll}](\\w|')*",
+      "flags": "u"
     },
     "_conid": {
       "type": "PATTERN",
-      "value": "[\\p{Lu}\\p{Lt}](\\w|')*#?"
+      "value": "[\\p{Lu}\\p{Lt}](\\w|')*#?",
+      "flags": "u"
     },
     "constructor": {
       "type": "SYMBOL",
@@ -10442,4 +10447,3 @@
   ],
   "supertypes": []
 }
-

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -13,9 +13,8 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-typedef uint16_t TSStateId;
-
 #ifndef TREE_SITTER_API_H_
+typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
@@ -130,9 +129,16 @@ struct TSLanguage {
  *  Lexer Macros
  */
 
+#ifdef _MSC_VER
+#define UNUSED __pragma(warning(suppress : 4101))
+#else
+#define UNUSED __attribute__((unused))
+#endif
+
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
+  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -166,7 +172,7 @@ struct TSLanguage {
  *  Parse Table Macros
  */
 
-#define SMALL_STATE(id) id - LARGE_STATE_COUNT
+#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
 
 #define STATE(id) id
 
@@ -176,7 +182,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = state_value            \
+      .state = (state_value)          \
     }                                 \
   }}
 
@@ -184,7 +190,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = state_value,           \
+      .state = (state_value),         \
       .repetition = true              \
     }                                 \
   }}


### PR DESCRIPTION
@tek @kazatsuyu the utf8 stuff in parser.c should not be there ideally, I fixed this a while ago upstream but you need to regenerate with a newer version of the cli to see the difference and have no more utf-8 characters. I've done that now with ts on master and reverted the utf8 stuff as a result. This is just a heads up :grin: 